### PR TITLE
Error from zinc

### DIFF
--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -34,7 +34,7 @@ object DefDefTransforms extends TreesChecks:
         .requiredType("Continuation")
         .typeRef
         .appliedTo(returnType)
-    )
+    ).entered
 
   private def params(tree: tpd.ValOrDefDef, completionSym: Symbol)(
       using Context): List[tpd.ParamClause] =
@@ -126,7 +126,7 @@ object DefDefTransforms extends TreesChecks:
       ),
       parent.privateWithin,
       parent.coord
-    )
+    ).entered
 
   private def removeSuspend(typ: Type, returnValue: Option[Type] = None)(using Context): Type =
     val types = flattenTypes(typ)
@@ -173,6 +173,9 @@ object DefDefTransforms extends TreesChecks:
       (returnType, rhs, contextFunctionOwner)
     else (tree.tpt.tpe, tree.rhs, Option.empty)
 
+  private def deleteOldSymbol(sym: Symbol)(using Context): Unit =
+    sym.enclosingClass.asClass.delete(sym)
+
   private def transformSuspendOneContinuationResume(
       tree: tpd.ValOrDefDef,
       suspensionPoint: tpd.Tree)(using Context): tpd.DefDef =
@@ -211,7 +214,7 @@ object DefDefTransforms extends TreesChecks:
     val transformedMethodSymbol =
       createTransformedMethodSymbol(parent, transformedMethodParams, finalMethodReturnType.tpe)
 
-    parent.owner.unforcedDecls.openForMutations.replace(parent, transformedMethodSymbol)
+    deleteOldSymbol(parent)
 
     val transformedMethod =
       tpd.DefDef(sym = transformedMethodSymbol)
@@ -225,7 +228,7 @@ object DefDefTransforms extends TreesChecks:
           transformedMethodSymbol,
           termName("continuation1"),
           Flags.Local,
-          continuationTyped),
+          continuationTyped).entered,
         rhs = transformedMethodCompletionParam)
 
     val undecidedState =
@@ -250,7 +253,7 @@ object DefDefTransforms extends TreesChecks:
           transformedMethodSymbol,
           termName("safeContinuation"),
           Flags.Local,
-          safeContinuationConstructor.tpe),
+          safeContinuationConstructor.tpe).entered,
         safeContinuationConstructor)
 
     val safeContinuationRef =
@@ -365,7 +368,7 @@ object DefDefTransforms extends TreesChecks:
         removeSuspendReturnAny(methodReturnType)
       )
 
-    parent.owner.unforcedDecls.openForMutations.replace(parent, transformedMethodSymbol)
+    deleteOldSymbol(parent)
 
     val transformedMethod =
       tpd.DefDef(sym = transformedMethodSymbol)
@@ -597,7 +600,7 @@ object DefDefTransforms extends TreesChecks:
         val transformedMethodSymbol =
           createTransformedMethodSymbol(parent, transformedMethodParams, newReturnType.tpe)
 
-        treeOwner.unforcedDecls.openForMutations.replace(parent, transformedMethodSymbol)
+        deleteOldSymbol(parent)
 
         val transformedMethod: tpd.DefDef =
           tpd.DefDef(sym = transformedMethodSymbol)
@@ -730,7 +733,7 @@ object DefDefTransforms extends TreesChecks:
                   tree.symbol.asTerm.name,
                   Local | Mutable | Synthetic,
                   tree.symbol.info,
-                  coord = tree.symbol.coord),
+                  coord = tree.symbol.coord).entered,
                 nullLiteral
               )
             }
@@ -745,7 +748,7 @@ object DefDefTransforms extends TreesChecks:
                   Local | Mutable | Synthetic,
                   vd.symbol.info,
                   coord = vd.symbol.coord
-                ),
+                ).entered,
                 ref(vd.symbol)
               )
           }
@@ -798,7 +801,10 @@ object DefDefTransforms extends TreesChecks:
               newParent,
               termName("$continuation"),
               Local | Mutable | Synthetic,
-              OrType(continuationClassRef.appliedTo(anyType), defn.NullType, soft = false)),
+              OrType(
+                continuationClassRef.appliedTo(anyType),
+                defn.NullType,
+                soft = false)).entered,
             nullLiteral
           )
 
@@ -808,7 +814,7 @@ object DefDefTransforms extends TreesChecks:
               .appliedToType(continuationStateMachineClass.tpe)
 
           val case11Param =
-            newSymbol(newParent, nme.x_0, Flags.Case | Flags.CaseAccessor, defn.AnyType)
+            newSymbol(newParent, nme.x_0, Flags.Case | Flags.CaseAccessor, defn.AnyType).entered
           val $continuationLabel =
             continuationAsStateMachineClass.select(continuationsStateMachineLabelParam)
           val case11 = tpd.CaseDef(
@@ -865,7 +871,7 @@ object DefDefTransforms extends TreesChecks:
                 newParent,
                 termName("$result"),
                 Local,
-                eitherThrowableAnyNullSuspendedType),
+                eitherThrowableAnyNullSuspendedType).entered,
               continuationAsStateMachineClass.select(continuationsStateMachineResultName)
             )
 
@@ -879,11 +885,15 @@ object DefDefTransforms extends TreesChecks:
                 .select(termName("fold"))
                 .appliedToType(defn.UnitType)
                 .appliedTo(
-                  tpd.Lambda(
-                    MethodType.apply(List(defn.ThrowableType))(_ => defn.NothingType),
-                    trees => tpd.Throw(trees.head)),
-                  tpd.Lambda(
-                    MethodType(List(anyNullSuspendedType))(_ => defn.UnitType),
+                  tpd.Closure(
+                    newAnonFun(
+                      newParent,
+                      MethodType(List(defn.ThrowableType))(_ => defn.NothingType)),
+                    trees => tpd.Throw(trees.head.head)),
+                  tpd.Closure(
+                    newAnonFun(
+                      newParent,
+                      MethodType(List(anyNullSuspendedType))(_ => defn.UnitType)),
                     _ => unitLiteral)
                 ),
               unitLiteral
@@ -891,7 +901,7 @@ object DefDefTransforms extends TreesChecks:
 
           val labels: List[Symbol] =
             rowsBeforeSuspensionPoint.keySet.toList.indices.toList.map { i =>
-              newSymbol(newParent, termName(s"label$i"), Flags.Label, defn.UnitType)
+              newSymbol(newParent, termName(s"label$i"), Flags.Label, defn.UnitType).entered
             }
 
           def paramsAndRowsBeforeSuspendIncludingSuspend(index: Int) =
@@ -968,7 +978,7 @@ object DefDefTransforms extends TreesChecks:
                       newParent,
                       termName("safeContinuation"),
                       Flags.Local,
-                      safeContinuationConstructor.tpe),
+                      safeContinuationConstructor.tpe).entered,
                     safeContinuationConstructor)
 
                 val safeContinuationRef =
@@ -983,7 +993,7 @@ object DefDefTransforms extends TreesChecks:
                       newParent,
                       termName("orThrow"),
                       Flags.Local,
-                      anyNullSuspendedType),
+                      anyNullSuspendedType).entered,
                     safeContinuationRef.select(termName("getOrThrow")).appliedToNone)
 
                 val assignGetOrThrowToGlobalVar =

--- a/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
+++ b/continuationsPlugin/src/test/scala/continuations/ContinuationsPluginSuite.scala
@@ -20,1595 +20,1597 @@ import munit.FunSuite
  */
 class ContinuationsPluginSuite extends FunSuite, CompilerFixtures, StateMachineFixtures {
 
-  compilerContextWithContinuationsPlugin.test(
-    """|it should transform a 0-arity suspended definition returning a
-       |non-blocking value into a definition accepting a continuation
-       |returning the non-blocking value""".stripMargin) {
-    case given Context =>
-      val source =
-        """|import continuations.*
-           |
-           |def program: Unit = {
-           | def foo()(using Suspend): Int = 1
-           | println(foo())
-           |}""".stripMargin
-        
-      // format: off
-      val expectedOutput =
-        """package <empty> {
-          |  import continuations.*
-          |  final lazy module val compileFromString$package:
-          |    compileFromString$package
-          |   = new compileFromString$package()
-          |  @SourceFile("compileFromString.scala") final module class
-          |    compileFromString$package
-          |  () extends Object() { this: compileFromString$package.type =>
-          |    private def writeReplace(): AnyRef =
-          |      new scala.runtime.ModuleSerializationProxy(classOf[compileFromString$package.type])
-          |    def program: Unit =
-          |      {
-          |        def foo(completion: continuations.Continuation[Int | Any]): Any = 1
-          |        println(foo(continuations.jvm.internal.ContinuationStub.contImpl))
-          |      }
-          |  }
-          |}
-           |""".stripMargin
-      // format: on
+//  compilerContextWithContinuationsPlugin.test(
+//    """|it should transform a 0-arity suspended definition returning a
+//       |non-blocking value into a definition accepting a continuation
+//       |returning the non-blocking value""".stripMargin) {
+//    case given Context =>
+//      val source =
+//        """|import continuations.*
+//           |
+//           |def program: Unit = {
+//           | def foo()(using Suspend): Int = 1
+//           | println(foo())
+//           |}""".stripMargin
+//
+//      // format: off
+//      val expectedOutput =
+//        """package <empty> {
+//          |  import continuations.*
+//          |  final lazy module val compileFromString$package:
+//          |    compileFromString$package
+//          |   = new compileFromString$package()
+//          |  @SourceFile("compileFromString.scala") final module class
+//          |    compileFromString$package
+//          |  () extends Object() { this: compileFromString$package.type =>
+//          |    private def writeReplace(): AnyRef =
+//          |      new scala.runtime.ModuleSerializationProxy(classOf[compileFromString$package.type])
+//          |    def program: Unit =
+//          |      {
+//          |        def foo(completion: continuations.Continuation[Int | Any]): Any = 1
+//          |        println(foo(continuations.jvm.internal.ContinuationStub.contImpl))
+//          |      }
+//          |  }
+//          |}
+//           |""".stripMargin
+//      // format: on
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            expectedOutput)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    """|it should transform a 0-arity suspended definition without empty parameters list returning a
+//       |non-blocking value into a definition accepting a continuation
+//       |returning the non-blocking value""".stripMargin) {
+//    case given Context =>
+//      val source =
+//        """| import continuations.*
+//           |
+//           |def program: Unit = {
+//           | def foo(using Suspend): Int = 1
+//           | println(foo)
+//           |}""".stripMargin
+//
+//      // format: off
+//      val expectedOutput =
+//        """|package <empty> {
+//           |  import continuations.*
+//           |  final lazy module val compileFromString$package:
+//           |    compileFromString$package
+//           |   = new compileFromString$package()
+//           |  @SourceFile("compileFromString.scala") final module class
+//           |    compileFromString$package
+//           |  () extends Object() { this: compileFromString$package.type =>
+//           |    private def writeReplace(): AnyRef =
+//           |      new scala.runtime.ModuleSerializationProxy(classOf[compileFromString$package.type])
+//           |    def program: Unit =
+//           |      {
+//           |        def foo(completion: continuations.Continuation[Int | Any]): Any = 1
+//           |        println(foo(continuations.jvm.internal.ContinuationStub.contImpl))
+//           |      }
+//           |  }
+//           |}
+//           |""".stripMargin
+//      // format: on
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            expectedOutput)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "It should work when there are no continuations") {
+//    case given Context =>
+//      val source = """|class A""".stripMargin
+//      // format: off
+//      val expected = """|package <empty> {
+//        |  @SourceFile("compileFromString.scala") class A() extends Object() {}
+//        |}
+//        |""".stripMargin
+//      // format: on
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "It should work when there are no continuations".fail) {
+//    case given Context =>
+//      val source = """|class A""".stripMargin
+//      val expected = """|package <empty> {
+//                        |  @SourceFile("compileFromString.scala") class B() extends Object() {}
+//                        |}""".stripMargin
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertEquals(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+//      }
+//  }
 
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            expectedOutput)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    """|it should transform a 0-arity suspended definition without empty parameters list returning a
-       |non-blocking value into a definition accepting a continuation
-       |returning the non-blocking value""".stripMargin) {
+  compilerContextWithContinuationsPlugin.test("debug") {
     case given Context =>
       val source =
         """| import continuations.*
            |
-           |def program: Unit = {
-           | def foo(using Suspend): Int = 1
-           | println(foo)
+           |object program {
+           | def foo()(using Suspend): Int = {
+           |  summon[Suspend].suspendContinuation[Int] { _.resume(Right(1)) }
+           |  1
+           | }
            |}""".stripMargin
 
-      // format: off
-      val expectedOutput =
-        """|package <empty> {
-           |  import continuations.*
-           |  final lazy module val compileFromString$package:
-           |    compileFromString$package
-           |   = new compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class
-           |    compileFromString$package
-           |  () extends Object() { this: compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef =
-           |      new scala.runtime.ModuleSerializationProxy(classOf[compileFromString$package.type])
-           |    def program: Unit =
-           |      {
-           |        def foo(completion: continuations.Continuation[Int | Any]): Any = 1
-           |        println(foo(continuations.jvm.internal.ContinuationStub.contImpl))
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            expectedOutput)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "It should work when there are no continuations") {
-    case given Context =>
-      val source = """|class A""".stripMargin
-      // format: off
-      val expected = """|package <empty> {
-        |  @SourceFile("compileFromString.scala") class A() extends Object() {}
-        |}
-        |""".stripMargin
-      // format: on
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "It should work when there are no continuations".fail) {
-    case given Context =>
-      val source = """|class A""".stripMargin
-      val expected = """|package <empty> {
-                        |  @SourceFile("compileFromString.scala") class B() extends Object() {}
-                        |}""".stripMargin
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertEquals(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
-      }
-  }
-
-  compilerContext.test("debug".ignore) {
-    case given Context =>
-      val source =
-        """|package continuations
-           |
-           |def foo()(using Suspend): Int = {
-           |  val x = 5
-           |  println("HI")
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
-           |}
-           |""".stripMargin
       checkCompile("pickleQuotes", source) {
-        case (tree, _) =>
-          assertEquals(tree.toString, """|""".stripMargin)
-      }
+          case (tree, _) =>
+            println(tree.show)
+            assertEquals(1, 1)
+        }
   }
 
-  compilerContextWithContinuationsPlugin.test(
-    "It should convert a suspended context function def with a single constant and a non suspended body to CPS"
-  ) {
-    case given Context =>
-      val source =
-        """
-          |import continuations.*
-          |
-          |def foo(x: Int): Suspend ?=> Int = x + 1
-          |""".stripMargin
-
-      // format: off
-      val expected =
-        """|package <empty> {
-           |  import continuations.*
-           |  final lazy module val compileFromString$package:
-           |    compileFromString$package
-           |   = new compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class
-           |    compileFromString$package
-           |  () extends Object() { this: compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef =
-           |      new scala.runtime.ModuleSerializationProxy(classOf[compileFromString$package.type])
-           |    def foo(x: Int, completion: continuations.Continuation[Int | Any]): Any = x.+(1)
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            removeLineTrailingSpaces(expected))
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "It should convert a suspended def with a single constant and a non suspended body to CPS"
-  ) {
-    case given Context =>
-      val source =
-        """
-          |import continuations.*
-          |
-          |def foo(x: Int)(using Suspend): Int = x + 1
-          |""".stripMargin
-
-      // format: off
-      val expected =
-        """|package <empty> {
-           |  import continuations.*
-           |  final lazy module val compileFromString$package: 
-           |    compileFromString$package
-           |   = new compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[compileFromString$package.type])
-           |    def foo(x: Int, completion: continuations.Continuation[Int | Any]): Any = x.+(1)
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "It should convert a suspended def with a single constant and a non suspended body to CPS"
-  ) {
-    case given Context =>
-      val source =
-        """
-          |import continuations.*
-          |import scala.concurrent.ExecutionContext
-          |
-          |def foo(x: Int, z: String*)(using s: Suspend, ec: ExecutionContext): Int = x + 1
-          |""".stripMargin
-
-      // format: off
-      val expected =
-        """|package <empty> {
-           |  import continuations.*
-           |  import scala.concurrent.ExecutionContext
-           |  final lazy module val compileFromString$package: 
-           |    compileFromString$package
-           |   = new compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[compileFromString$package.type])
-           |    def foo(x: Int, z: String*, ec: concurrent.ExecutionContext, completion: continuations.Continuation[Int | Any]): Any = x.+(1)
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
-      }
-  }
-
-  compilerContext.test("It should run the compiler") {
-    case given Context =>
-      val source = """
-                     |class A
-                     |class B extends A
-    """.stripMargin
-
-      val types = List(
-        "A",
-        "B",
-        "List[?]",
-        "List[Int]",
-        "List[AnyRef]",
-        "List[String]",
-        "List[A]",
-        "List[B]"
-      )
-
-      checkTypes(source, types: _*) {
-        case (List(a, b, lu, li, lr, ls, la, lb), context) =>
-          given Context = context
-          assert(b <:< a)
-          assert(li <:< lu)
-          assert(!(li <:< lr))
-          assert(ls <:< lr)
-          assert(lb <:< la)
-          assert(!(la <:< lb))
-
-        case _ => fail(s"no list or context compiled from source ${source}, ${types}")
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with a Right input") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            compileSourceIdentifier.replaceAllIn(tree.show, ""),
-            expectedOneSuspendContinuation)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with a Right input using braces") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int](continuation => continuation.resume(Right(1)))
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            compileSourceIdentifier.replaceAllIn(tree.show, ""),
-            expectedOneSuspendContinuation)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with a Right input but no inner var") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int] { _.resume(Right(1)) }
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            compileSourceIdentifier.replaceAllIn(tree.show, ""),
-            expectedOneSuspendContinuation)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with a Right input but no inner var using braces") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int](_.resume(Right(1)))
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            compileSourceIdentifier.replaceAllIn(tree.show, ""),
-            expectedOneSuspendContinuation)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with a Left input") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Left(new Exception("error"))) }
-           |""".stripMargin
-
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
-           |      {
-           |        val continuation1: continuations.Continuation[Int] = completion
-           |        val safeContinuation: continuations.SafeContinuation[Int] = 
-           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
-           |            continuations.Continuation.State.Undecided
-           |          )
-           |        safeContinuation.resume(Left.apply[Exception, Nothing](new Exception("error")))
-           |        safeContinuation.getOrThrow()
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with multiple expressions in the body") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |
-           |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int]{ c =>
-           |    println("Hello")
-           |    c.resume(Right(1))
-           |    val x = 1
-           |    val y = false
-           |    c.resume(Right(2))
-           |    println(x)
-           |  }
-           |""".stripMargin
-
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
-           |      {
-           |        val continuation1: continuations.Continuation[Int] = completion
-           |        val safeContinuation: continuations.SafeContinuation[Int] = 
-           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
-           |            continuations.Continuation.State.Undecided
-           |          )
-           |        println("Hello")
-           |        safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |        val x: Int = 1
-           |        val y: Boolean = false
-           |        safeContinuation.resume(Right.apply[Nothing, Int](2))
-           |        println(x)
-           |        safeContinuation.getOrThrow()
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with vals inside resume") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |
-           |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int]{ c =>
-           |    c.resume{
-           |      println("Hello")
-           |      val x = 1
-           |      val y = 1
-           |      Right(x + y)
-           |    }
-           |  }
-           |""".stripMargin
-
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
-           |      {
-           |        val continuation1: continuations.Continuation[Int] = completion
-           |        val safeContinuation: continuations.SafeContinuation[Int] = 
-           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
-           |            continuations.Continuation.State.Undecided
-           |          )
-           |        safeContinuation.resume(
-           |          {
-           |            println("Hello")
-           |            val x: Int = 1
-           |            val y: Int = 1
-           |            Right.apply[Nothing, Int](x.+(y))
-           |          }
-           |        )
-           |        safeContinuation.getOrThrow()
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with a named implicit Suspend") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def foo()(using s: Suspend): Int =
-           |  s.suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            compileSourceIdentifier.replaceAllIn(tree.show, ""),
-            expectedOneSuspendContinuation)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with a context function that has Suspend") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def foo(): Suspend ?=> Int =
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            compileSourceIdentifier.replaceAllIn(tree.show, ""),
-            expectedOneSuspendContinuation)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters keeping the rows before the suspend call") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def foo()(using Suspend): Int = {
-           |  val x = 5
-           |  println("HI")
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
-           |}
-           |""".stripMargin
-
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
-           |      {
-           |        val x: Int = 5
-           |        println("HI")
-           |        {
-           |          val continuation1: continuations.Continuation[Int] = completion
-           |          val safeContinuation: continuations.SafeContinuation[Int] = 
-           |            new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
-           |              continuations.Continuation.State.Undecided
-           |            )
-           |          safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |          safeContinuation.getOrThrow()
-           |        }
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should even convert suspended def with no parameters that doesn't call resume") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def foo()(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int] { _ => val x = 1; println("Hello") }
-           |""".stripMargin
-
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
-           |      {
-           |        val continuation1: continuations.Continuation[Int] = completion
-           |        val safeContinuation: continuations.SafeContinuation[Int] = 
-           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
-           |            continuations.Continuation.State.Undecided
-           |          )
-           |        val x: Int = 1
-           |        println("Hello")
-           |        safeContinuation.getOrThrow()
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with a single constant parameter with a Right input") {
-    implicit givenContext =>
-
-      val source =
-        """|
-           |package continuations
-           |
-           |def foo(x: Int)(using Suspend): Int =
-           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(x + 1)) }
-           |""".stripMargin
-
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def foo(x: Int, completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
-           |      {
-           |        val continuation1: continuations.Continuation[Int] = completion
-           |        val safeContinuation: continuations.SafeContinuation[Int] = 
-           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
-           |            continuations.Continuation.State.Undecided
-           |          )
-           |        safeContinuation.resume(Right.apply[Nothing, Int](x.+(1)))
-           |        safeContinuation.getOrThrow()
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert a zero arity definition that contains a suspend call but returns a non-suspending value " +
-      "into a state machine including an update of the call site:") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def program: Int = {
-           |  def foo()(using Suspend): Int = {
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
-           |    10
-           |  }
-           |  foo()
-           |}
-           |""".stripMargin
-
-      val sourceContextFunction =
-        """|
-           |package continuations
-           |
-           |def program: Int = {
-           |  def foo(): Suspend ?=> Int = {
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
-           |    10
-           |  }
-           |  foo()
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            compileSourceIdentifier.replaceAllIn(tree.show, ""),
-            expectedStateMachineForSuspendContinuationReturningANonSuspendingVal)
-      }
-
-      checkContinuations(sourceContextFunction) {
-        case (tree, _) =>
-          assertNoDiff(
-            compileSourceIdentifier.replaceAllIn(tree.show, ""),
-            expectedStateMachineForSuspendContinuationReturningANonSuspendingVal)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert a >0 arity definition that contains a suspend call but returns a non-suspending value " +
-      "into a state machine including an update of the call site:") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def program: Int = {
-           |  def foo(x: Int)(using Suspend): Int = {
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(x)) }
-           |    10
-           |  }
-           |  foo(11)
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            compileSourceIdentifier.replaceAllIn(tree.show, ""),
-            expectedStateMachineWithSingleSuspendedContinuationReturningANonSuspendedVal)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple nested suspended def with a single parameter keeping the rest of the rows untouched") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def foo(x: Int)(using Suspend): Int = {
-           |  val y = 5
-           |  println("HI")
-           |  if (x < y) then {
-           |    x
-           |  } else {
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
-           |  }
-           |}
-           |""".stripMargin
-
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def foo(x: Int, completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type = 
-           |      {
-           |        val y: Int = 5
-           |        println("HI")
-           |        if x.<(y) then 
-           |          {
-           |            x
-           |          }
-           |         else 
-           |          {
-           |            {
-           |              val continuation1: continuations.Continuation[Int] = completion
-           |              val safeContinuation: continuations.SafeContinuation[Int] = 
-           |                new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(), 
-           |                  continuations.Continuation.State.Undecided
-           |                )
-           |              safeContinuation.resume(Right.apply[Nothing, Int](1))
-           |              safeContinuation.getOrThrow()
-           |            }
-           |          }
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with multiple `suspendContinuation` that returns " +
-      "a non-suspending value into a state machine including an update of the call site:") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def program: Int = {
-           |  def foo()(using Suspend): Int = {
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
-           |    summon[Suspend].suspendContinuation[Boolean] { continuation => continuation.resume(Right(false)) }
-           |    summon[Suspend].suspendContinuation[String] { continuation => continuation.resume(Right("Hello")) }
-           |    10
-           |  }
-           |
-           |foo()
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            compileSourceIdentifier.replaceAllIn(tree.show, ""),
-            expectedStateMachineMultipleSuspendedContinuationsReturningANonSuspendingVal)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with multiple `suspendContinuation` that returns " +
-      "a non-suspending value and with multiple expressions in the suspendContinuation body into a state machine " +
-      "including an update of the call site:") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def program: Int = {
-           |  def foo()(using Suspend): Int = {
-           |    summon[Suspend].suspendContinuation[Int] { continuation =>
-           |      println("Hello")
-           |      println("World")
-           |      continuation.resume(Right(1))
-           |    }
-           |    summon[Suspend].suspendContinuation[Boolean] { continuation =>
-           |      continuation.resume(Right(false))
-           |      continuation.resume(Right(true))
-           |    }
-           |    summon[Suspend].suspendContinuation[String] { continuation =>
-           |      continuation.resume(Right("Hello"))
-           |      val x = 1
-           |    }
-           |    10
-           |  }
-           |
-           |foo()
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            compileSourceIdentifier.replaceAllIn(tree.show, ""),
-            expectedStateMachineWithMultipleResumeReturningANonSuspendedValue)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert a zero arity definition that contains suspend " +
-      "calls with expressions between them and returns a non-suspending value into a state machine including an update of the call site:") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def program: Int = {
-           |  def foo()(using Suspend): Int = {
-           |    println("Start")
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
-           |    val x = "World"
-           |    println("Hello")
-           |    println(x)
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(2)) }
-           |    println("End")
-           |    10
-           |  }
-           |  foo()
-           |}
-           |""".stripMargin
-
-      val sourceContextFunction =
-        """|
-           |package continuations
-           |
-           |def program: Int = {
-           |  def foo(): Suspend ?=> Int = {
-           |    println("Start")
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
-           |    val x = "World"
-           |    println("Hello")
-           |    println(x)
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(2)) }
-           |    println("End")
-           |    10
-           |  }
-           |  foo()
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            compileSourceIdentifier.replaceAllIn(tree.show, ""),
-            expectedStateMachineReturningANonSuspendedValue)
-      }
-
-      checkContinuations(sourceContextFunction) {
-        case (tree, _) =>
-          assertNoDiff(
-            compileSourceIdentifier.replaceAllIn(tree.show, ""),
-            expectedStateMachineReturningANonSuspendedValue)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with multiple `suspendContinuation` " +
-      "into a state machine including an update of the call site:") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def program: Int = {
-           |  def foo()(using Suspend): Int = {
-           |    summon[Suspend].suspendContinuation[Boolean] { continuation => continuation.resume(Right(false)) }
-           |    summon[Suspend].suspendContinuation[String] { continuation => continuation.resume(Right("Hello")) }
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
-           |  }
-           |
-           |foo()
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            compileSourceIdentifier.replaceAllIn(tree.show, ""),
-            expectedStateMachineNoDependantSuspensions)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with multiple `suspendContinuation` " +
-      "and with multiple expressions in the suspendContinuation body into a state machine including an update of the call site:") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def program: Int = {
-           |  def foo()(using Suspend): Int = {
-           |    summon[Suspend].suspendContinuation[Boolean] { continuation =>
-           |      println("Hi")
-           |      continuation.resume(Right(false))
-           |    }
-           |    summon[Suspend].suspendContinuation[String] {
-           |      continuation => continuation.resume(Right("Hello"))
-           |      println("World")
-           |    }
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
-           |  }
-           |
-           |foo()
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            compileSourceIdentifier.replaceAllIn(tree.show, ""),
-            expectedStateMachineNoDependantSuspensionsWithCodeInside)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert simple suspended def with no parameters with multiple `suspendContinuation` " +
-      "and with expressions between them into a state machine including an update of the call site:") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def program: Int = {
-           |  def foo()(using Suspend): Int = {
-           |    println("Start")
-           |    val x = 1
-           |    summon[Suspend].suspendContinuation[Boolean] { continuation => continuation.resume(Right(false)) }
-           |    println("Hello")
-           |    summon[Suspend].suspendContinuation[String] { continuation => continuation.resume(Right("Hello")) }
-           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
-           |  }
-           |
-           |foo()
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            compileSourceIdentifier.replaceAllIn(tree.show, ""),
-            expectedStateMachineNoDependantSuspensionsWithCodeBetween)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should transform the method parameters adding a completion one and updating the call site when there is " +
-      "a `using Suspend` parameter") {
-    case given Context =>
-      val sourceNoSuspend =
-        """|
-           |package continuations
-           |
-           |import scala.concurrent.ExecutionContext
-           |import concurrent.ExecutionContext.Implicits.global
-           |
-           |def program: Int = {
-           |  def foo[A, B](x: A, y: B)(z: String)(using s: Suspend, ec: ExecutionContext): A = x
-           |  foo(1,2)("A")
-           |}
-           |""".stripMargin
-
-      val sourceSuspend =
-        """|
-           |package continuations
-           |
-           |import scala.concurrent.ExecutionContext
-           |import concurrent.ExecutionContext.Implicits.global
-           |
-           |def program: Int = {
-           |  def foo[A, B](x: A, y: B)(z: String)(using s: Suspend, ec: ExecutionContext): A =
-           |    summon[Suspend].suspendContinuation[A] { continuation => continuation.resume(Right(x)) }
-           |  foo(1,2)("A")
-           |}
-           |""".stripMargin
-
-      // format: off
-      val expectedNoSuspend =
-        """|
-           |package continuations {
-           |  import scala.concurrent.ExecutionContext
-           |  import concurrent.ExecutionContext.Implicits.global
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def program: Int =
-           |      {
-           |        def foo(x: A, y: B, z: String, ec: concurrent.ExecutionContext, completion: continuations.Continuation[A | Any]): Any = x
-           |        foo(1, 2, "A", concurrent.ExecutionContext.Implicits.global, continuations.jvm.internal.ContinuationStub.contImpl)
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-
-      val expectedSuspend =
-        """|
-           |package continuations {
-           |  import scala.concurrent.ExecutionContext
-           |  import concurrent.ExecutionContext.Implicits.global
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def program: Int =
-           |      {
-           |        def foo(x: A, y: B, z: String, ec: concurrent.ExecutionContext, completion: continuations.Continuation[A]): 
-           |          Any | Null | continuations.Continuation.State.Suspended.type
-           |         = 
-           |          {
-           |            val continuation1: continuations.Continuation[A] = completion
-           |            val safeContinuation: continuations.SafeContinuation[A] = 
-           |              new continuations.SafeContinuation[A](continuations.intrinsics.IntrinsicsJvm$package.intercepted[A](continuation1)(), 
-           |                continuations.Continuation.State.Undecided
-           |              )
-           |            safeContinuation.resume(Right.apply[Nothing, A](x))
-           |            safeContinuation.getOrThrow()
-           |          }
-           |        foo(1, 2, "A", concurrent.ExecutionContext.Implicits.global, continuations.jvm.internal.ContinuationStub.contImpl)
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
-      checkContinuations(sourceNoSuspend) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            removeLineTrailingSpaces(expectedNoSuspend))
-      }
-
-      checkContinuations(sourceSuspend) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            removeLineTrailingSpaces(expectedSuspend))
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should transform a dependent suspendContinuation with one param into a state machine") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def foo(x: Int)(using Suspend): Int = {
-           |  val y = summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
-           |  x + y
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            removeLineTrailingSpaces(expectedStateMachineOneParamOneDependantContinuation)
-          )
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should transform a suspend continuation with one parameter into a state machine"
-  ) {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def foo(qq: Int)(using s: Suspend): Int = {
-           |  summon[Suspend].suspendContinuation[Unit] { _.resume(Right { println(qq) }) }
-           |  10
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            removeLineTrailingSpaces(expectedStateMachineOneParamOneNoDependantContinuation)
-          )
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should transform a suspend continuation with no parameter and code before the continuation " +
-      "that is used afterwards into a state machine"
-  ) {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def foo()(using s: Suspend): Int = {
-           |  val xx = 111
-           |  println(xx)
-           |  summon[Suspend].suspendContinuation[Int] { _.resume(Right( 10 )) }
-           |  xx
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            removeLineTrailingSpaces(
-              expectedStateMachineNoParamOneNoDependantContinuationCodeBeforeUsedAfter)
-          )
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should transform a suspend continuation with many dependant continuations " +
-      "with code around them to a state machine"
-  ) {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def fooTest(qq: Int)(using s: Suspend): Int = {
-           |    val pp = 11
-           |    val xx = s.suspendContinuation[Int] { _.resume(Right { qq - 1 }) }
-           |    val ww = 13
-           |    val rr = "AAA"
-           |    val yy = s.suspendContinuation[String] { _.resume(Right { rr }) }
-           |    val tt = 100
-           |    val zz = s.suspendContinuation[Int] { _.resume(Right { ww - 1 }) }
-           |    println(xx)
-           |    xx + qq + yy.size + zz + pp + tt
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            removeLineTrailingSpaces(expectedStateMachineManyDependantContinuations)
-          )
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should transform a suspend continuation with many dependant and no dependant continuations " +
-      "with code around them to a state machine"
-  ) {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def fooTest(qq: Int)(using s: Suspend): Int = {
-           |    val pp = 11
-           |    val xx = s.suspendContinuation[Int] { _.resume(Right { qq - 1 }) }
-           |    val ww = 13
-           |    val rr = "AAA"
-           |    s.suspendContinuation[String] { _.resume(Right { rr }) }
-           |    val tt = 100
-           |    val zz = s.suspendContinuation[Int] { _.resume(Right { ww - 1 }) }
-           |    println(xx)
-           |    xx + qq + zz + pp + tt
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            removeLineTrailingSpaces(
-              expectedStateMachineManyDependantAndNoDependantContinuations)
-          )
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should transform a suspend continuation with dependant and no dependant continuation at the end" +
-      "with code around them and inside to a state machine"
-  ) {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def fooTest(x: Int)(using s: Suspend): Int = {
-           |    println("Hello")
-           |    val y = s.suspendContinuation[Int] { _.resume(Right { println("World"); 1 }) }
-           |    val z = 1
-           |    s.suspendContinuation[Int] { continuation =>
-           |      val w = "World"
-           |      println("Hello")
-           |      continuation.resume(Right { println(z); x })
-           |    }
-           |    val tt = 2
-           |    x + y + tt
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            removeLineTrailingSpaces(
-              expectedStateMachineWithDependantAndNoDependantContinuationAtTheEnd)
-          )
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert into a state machine for one chained suspend continuation"
-  ) {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def fooTest()(using s: Suspend): Int = {
-           |    val x = s.suspendContinuation[Int] { _.resume(Right { 1 }) }
-           |    s.suspendContinuation[Int] { _.resume(Right { x + 1 }) }
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            removeLineTrailingSpaces(expectedStateMachineForOneChainedContinuation)
-          )
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert into a state machine multiple chained continuations with" +
-      "code in between and returning a non suspended value"
-  ) {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def fooTest(q: Int)(using s: Suspend): Int = {
-           |    println("Hello")
-           |    val z = 100
-           |    val x = s.suspendContinuation[Int] { _.resume(Right { 1 + z}) }
-           |    val j = 9
-           |    val w = s.suspendContinuation[Int] { _.resume(Right { x + 1 + q}) }
-           |    println("World")
-           |    s.suspendContinuation[Int] { _.resume(Right { x + w + 1 + j}) }
-           |    10
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            removeLineTrailingSpaces(
-              expectedStateMachineMultipleChainedSuspendContinuationsReturningANonSuspendedVal)
-          )
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should update the call site for a simple suspended def with a generic param ") {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def program = {
-           |  case class Foo(i: Int)
-           |  def foo[A](a: A)(using Suspend): A = a
-           |  foo(Foo(1))
-           |}
-           |""".stripMargin
-
-      // format: off
-      val expected =
-        """|
-           |package continuations {
-           |  final lazy module val compileFromString$package: 
-           |    continuations.compileFromString$package
-           |   = new continuations.compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class 
-           |    compileFromString$package
-           |  () extends Object() { this: continuations.compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef = 
-           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
-           |    def program: Object = 
-           |      {
-           |        case class Foo(i: Int) extends Object(), _root_.scala.Product, _root_.scala.Serializable {
-           |          override def hashCode(): Int = 
-           |            {
-           |              var acc: Int = -889275714
-           |              acc = scala.runtime.Statics#mix(acc, this.productPrefix.hashCode())
-           |              acc = scala.runtime.Statics#mix(acc, Foo.this.i)
-           |              scala.runtime.Statics#finalizeHash(acc, 1)
-           |            }
-           |          override def equals(x$0: Any): Boolean = 
-           |            this.eq(x$0.$asInstanceOf[Object]).||(
-           |              x$0 match 
-           |                {
-           |                  case x$0 @ _:Foo @unchecked => this.i.==(x$0.i).&&(x$0.canEqual(this))
-           |                  case _ => false
-           |                }
-           |            )
-           |          override def toString(): String = scala.runtime.ScalaRunTime._toString(this)
-           |          override def canEqual(that: Any): Boolean = that.isInstanceOf[Foo @unchecked]
-           |          override def productArity: Int = 1
-           |          override def productPrefix: String = "Foo"
-           |          override def productElement(n: Int): Any = 
-           |            n match 
-           |              {
-           |                case 0 => this._1
-           |                case _ => throw new IndexOutOfBoundsException(n.toString())
-           |              }
-           |          override def productElementName(n: Int): String = 
-           |            n match 
-           |              {
-           |                case 0 => "i"
-           |                case _ => throw new IndexOutOfBoundsException(n.toString())
-           |              }
-           |          val i: Int
-           |          def copy(i: Int): Foo = new Foo(i)
-           |          def copy$default$1: Int @uncheckedVariance = Foo.this.i
-           |          def _1: Int = this.i
-           |        }
-           |        final lazy module val Foo: Foo = new Foo()
-           |        final module class Foo() extends AnyRef(), scala.deriving.Mirror.Product { this: Foo.type =>
-           |          def apply(i: Int): Foo = new Foo(i)
-           |          def unapply(x$1: Foo): Foo = x$1
-           |          override def toString: String = "Foo"
-           |          type MirroredMonoType = Foo
-           |          def fromProduct(x$0: Product): continuations.compileFromString$package.Foo.MirroredMonoType = 
-           |            new Foo(x$0.productElement(0).$asInstanceOf[Int])
-           |        }
-           |        def foo(a: A, completion: continuations.Continuation[A | Any]): Any = a
-           |        foo(Foo.apply(1), continuations.jvm.internal.ContinuationStub.contImpl):Object & Product & Serializable
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert into a state machine chained continuations with an input parameter"
-  ) {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def fooTest(x: Int)(using Suspend): Int = {
-           |    val y = summon[Suspend].suspendContinuation[Int] { continuation =>
-           |      continuation.resume(Right(x + 1))
-           |    }
-           |    summon[Suspend].suspendContinuation[Int] { continuation =>
-           |      continuation.resume(Right(y + 1))
-           |    }
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            removeLineTrailingSpaces(
-              expectedStateMachineChainedSuspendContinuationsOneParameter)
-          )
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "it should convert into a state machine chained continuations with an input parameter and vals"
-  ) {
-    case given Context =>
-      val source =
-        """|
-           |package continuations
-           |
-           |def fooTest(x: Int)(using Suspend): Int = {
-           |    val q = 2
-           |    val w = 3
-           |    val y = summon[Suspend].suspendContinuation[Int] { continuation =>
-           |      continuation.resume(Right(x + w))
-           |    }
-           |    val p = 1
-           |    val t = 1
-           |    val z = summon[Suspend].suspendContinuation[Int] { continuation =>
-           |      continuation.resume(Right(y + q + x))
-           |    }
-           |    z + y + p
-           |}
-           |""".stripMargin
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            removeLineTrailingSpaces(
-              expectedStateMachineChainedSuspendContinuationsOneParameterAndVals)
-          )
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "It should convert a polymorphic function with suspended context and a non suspended body to CPS"
-  ) {
-    case given Context =>
-      val source =
-        """
-          |import continuations.*
-          |
-          |def foo: Suspend ?=> Int => Int = x => x + 1
-          |""".stripMargin
-
-      // format: off
-      val expected =
-        """|package <empty> {
-           |  import continuations.*
-           |  final lazy module val compileFromString$package:
-           |    compileFromString$package
-           |   = new compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class
-           |    compileFromString$package
-           |  () extends Object() { this: compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef =
-           |      new scala.runtime.ModuleSerializationProxy(classOf[compileFromString$package.type])
-           |    def foo(completion: continuations.Continuation[(Int => Int) | Any]): Int => Any =
-           |      {
-           |        def $anonfun(x: Int): Any = x.+(1)
-           |        closure($anonfun)
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            removeLineTrailingSpaces(expected))
-      }
-  }
-
-  compilerContextWithContinuationsPlugin.test(
-    "It should convert a polymorphic function value with suspended context param a non suspended body to CPS"
-  ) {
-    case given Context =>
-      val source =
-        """
-          |import continuations.*
-          |
-          |val foo:  Suspend ?=> [A] => List[A] => Int = [A] => (list: List[A]) => list.size
-          |""".stripMargin
-
-      // format: off
-      val expected =
-        """|package <empty> {
-           |  import continuations.*
-           |  final lazy module val compileFromString$package:
-           |    compileFromString$package
-           |   = new compileFromString$package()
-           |  @SourceFile("compileFromString.scala") final module class
-           |    compileFromString$package
-           |  () extends Object() { this: compileFromString$package.type =>
-           |    private def writeReplace(): AnyRef =
-           |      new scala.runtime.ModuleSerializationProxy(classOf[compileFromString$package.type])
-           |    def foo(completion: continuations.Continuation[([A] => (List[A]) => Int) | Any]): [A] => (List[A]) => Any =
-           |      {
-           |        final class $anon() extends Object(), PolyFunction {
-           |          def apply[A >: Nothing <: Any](list: List[A]): Int = list.size
-           |        }
-           |        new $anon():([A] => (List[A]) => Int)
-           |      }
-           |  }
-           |}
-           |""".stripMargin
-      // format: on
-
-      checkContinuations(source) {
-        case (tree, _) =>
-          assertNoDiff(
-            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
-            removeLineTrailingSpaces(expected))
-      }
-  }
+//  compilerContextWithContinuationsPlugin.test(
+//    "It should convert a suspended context function def with a single constant and a non suspended body to CPS"
+//  ) {
+//    case given Context =>
+//      val source =
+//        """
+//          |import continuations.*
+//          |
+//          |def foo(x: Int): Suspend ?=> Int = x + 1
+//          |""".stripMargin
+//
+//      // format: off
+//      val expected =
+//        """|package <empty> {
+//           |  import continuations.*
+//           |  final lazy module val compileFromString$package:
+//           |    compileFromString$package
+//           |   = new compileFromString$package()
+//           |  @SourceFile("compileFromString.scala") final module class
+//           |    compileFromString$package
+//           |  () extends Object() { this: compileFromString$package.type =>
+//           |    private def writeReplace(): AnyRef =
+//           |      new scala.runtime.ModuleSerializationProxy(classOf[compileFromString$package.type])
+//           |    def foo(x: Int, completion: continuations.Continuation[Int | Any]): Any = x.+(1)
+//           |  }
+//           |}
+//           |""".stripMargin
+//      // format: on
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            removeLineTrailingSpaces(expected))
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "It should convert a suspended def with a single constant and a non suspended body to CPS"
+//  ) {
+//    case given Context =>
+//      val source =
+//        """
+//          |import continuations.*
+//          |
+//          |def foo(x: Int)(using Suspend): Int = x + 1
+//          |""".stripMargin
+//
+//      // format: off
+//      val expected =
+//        """|package <empty> {
+//           |  import continuations.*
+//           |  final lazy module val compileFromString$package:
+//           |    compileFromString$package
+//           |   = new compileFromString$package()
+//           |  @SourceFile("compileFromString.scala") final module class
+//           |    compileFromString$package
+//           |  () extends Object() { this: compileFromString$package.type =>
+//           |    private def writeReplace(): AnyRef =
+//           |      new scala.runtime.ModuleSerializationProxy(classOf[compileFromString$package.type])
+//           |    def foo(x: Int, completion: continuations.Continuation[Int | Any]): Any = x.+(1)
+//           |  }
+//           |}
+//           |""".stripMargin
+//      // format: on
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "It should convert a suspended def with a single constant and a non suspended body to CPS"
+//  ) {
+//    case given Context =>
+//      val source =
+//        """
+//          |import continuations.*
+//          |import scala.concurrent.ExecutionContext
+//          |
+//          |def foo(x: Int, z: String*)(using s: Suspend, ec: ExecutionContext): Int = x + 1
+//          |""".stripMargin
+//
+//      // format: off
+//      val expected =
+//        """|package <empty> {
+//           |  import continuations.*
+//           |  import scala.concurrent.ExecutionContext
+//           |  final lazy module val compileFromString$package:
+//           |    compileFromString$package
+//           |   = new compileFromString$package()
+//           |  @SourceFile("compileFromString.scala") final module class
+//           |    compileFromString$package
+//           |  () extends Object() { this: compileFromString$package.type =>
+//           |    private def writeReplace(): AnyRef =
+//           |      new scala.runtime.ModuleSerializationProxy(classOf[compileFromString$package.type])
+//           |    def foo(x: Int, z: String*, ec: concurrent.ExecutionContext, completion: continuations.Continuation[Int | Any]): Any = x.+(1)
+//           |  }
+//           |}
+//           |""".stripMargin
+//      // format: on
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+//      }
+//  }
+//
+//  compilerContext.test("It should run the compiler") {
+//    case given Context =>
+//      val source = """
+//                     |class A
+//                     |class B extends A
+//    """.stripMargin
+//
+//      val types = List(
+//        "A",
+//        "B",
+//        "List[?]",
+//        "List[Int]",
+//        "List[AnyRef]",
+//        "List[String]",
+//        "List[A]",
+//        "List[B]"
+//      )
+//
+//      checkTypes(source, types: _*) {
+//        case (List(a, b, lu, li, lr, ls, la, lb), context) =>
+//          given Context = context
+//          assert(b <:< a)
+//          assert(li <:< lu)
+//          assert(!(li <:< lr))
+//          assert(ls <:< lr)
+//          assert(lb <:< la)
+//          assert(!(la <:< lb))
+//
+//        case _ => fail(s"no list or context compiled from source ${source}, ${types}")
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple suspended def with no parameters with a Right input") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def foo()(using Suspend): Int =
+//           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+//            expectedOneSuspendContinuation)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple suspended def with no parameters with a Right input using braces") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def foo()(using Suspend): Int =
+//           |  summon[Suspend].suspendContinuation[Int](continuation => continuation.resume(Right(1)))
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+//            expectedOneSuspendContinuation)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple suspended def with no parameters with a Right input but no inner var") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def foo()(using Suspend): Int =
+//           |  summon[Suspend].suspendContinuation[Int] { _.resume(Right(1)) }
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+//            expectedOneSuspendContinuation)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple suspended def with no parameters with a Right input but no inner var using braces") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def foo()(using Suspend): Int =
+//           |  summon[Suspend].suspendContinuation[Int](_.resume(Right(1)))
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+//            expectedOneSuspendContinuation)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple suspended def with no parameters with a Left input") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def foo()(using Suspend): Int =
+//           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Left(new Exception("error"))) }
+//           |""".stripMargin
+//
+//      // format: off
+//      val expected =
+//        """|
+//           |package continuations {
+//           |  final lazy module val compileFromString$package:
+//           |    continuations.compileFromString$package
+//           |   = new continuations.compileFromString$package()
+//           |  @SourceFile("compileFromString.scala") final module class
+//           |    compileFromString$package
+//           |  () extends Object() { this: continuations.compileFromString$package.type =>
+//           |    private def writeReplace(): AnyRef =
+//           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+//           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type =
+//           |      {
+//           |        val continuation1: continuations.Continuation[Int] = completion
+//           |        val safeContinuation: continuations.SafeContinuation[Int] =
+//           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(),
+//           |            continuations.Continuation.State.Undecided
+//           |          )
+//           |        safeContinuation.resume(Left.apply[Exception, Nothing](new Exception("error")))
+//           |        safeContinuation.getOrThrow()
+//           |      }
+//           |  }
+//           |}
+//           |""".stripMargin
+//      // format: on
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple suspended def with no parameters with multiple expressions in the body") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |
+//           |def foo()(using Suspend): Int =
+//           |  summon[Suspend].suspendContinuation[Int]{ c =>
+//           |    println("Hello")
+//           |    c.resume(Right(1))
+//           |    val x = 1
+//           |    val y = false
+//           |    c.resume(Right(2))
+//           |    println(x)
+//           |  }
+//           |""".stripMargin
+//
+//      // format: off
+//      val expected =
+//        """|
+//           |package continuations {
+//           |  final lazy module val compileFromString$package:
+//           |    continuations.compileFromString$package
+//           |   = new continuations.compileFromString$package()
+//           |  @SourceFile("compileFromString.scala") final module class
+//           |    compileFromString$package
+//           |  () extends Object() { this: continuations.compileFromString$package.type =>
+//           |    private def writeReplace(): AnyRef =
+//           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+//           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type =
+//           |      {
+//           |        val continuation1: continuations.Continuation[Int] = completion
+//           |        val safeContinuation: continuations.SafeContinuation[Int] =
+//           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(),
+//           |            continuations.Continuation.State.Undecided
+//           |          )
+//           |        println("Hello")
+//           |        safeContinuation.resume(Right.apply[Nothing, Int](1))
+//           |        val x: Int = 1
+//           |        val y: Boolean = false
+//           |        safeContinuation.resume(Right.apply[Nothing, Int](2))
+//           |        println(x)
+//           |        safeContinuation.getOrThrow()
+//           |      }
+//           |  }
+//           |}
+//           |""".stripMargin
+//      // format: on
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple suspended def with no parameters with vals inside resume") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |
+//           |def foo()(using Suspend): Int =
+//           |  summon[Suspend].suspendContinuation[Int]{ c =>
+//           |    c.resume{
+//           |      println("Hello")
+//           |      val x = 1
+//           |      val y = 1
+//           |      Right(x + y)
+//           |    }
+//           |  }
+//           |""".stripMargin
+//
+//      // format: off
+//      val expected =
+//        """|
+//           |package continuations {
+//           |  final lazy module val compileFromString$package:
+//           |    continuations.compileFromString$package
+//           |   = new continuations.compileFromString$package()
+//           |  @SourceFile("compileFromString.scala") final module class
+//           |    compileFromString$package
+//           |  () extends Object() { this: continuations.compileFromString$package.type =>
+//           |    private def writeReplace(): AnyRef =
+//           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+//           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type =
+//           |      {
+//           |        val continuation1: continuations.Continuation[Int] = completion
+//           |        val safeContinuation: continuations.SafeContinuation[Int] =
+//           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(),
+//           |            continuations.Continuation.State.Undecided
+//           |          )
+//           |        safeContinuation.resume(
+//           |          {
+//           |            println("Hello")
+//           |            val x: Int = 1
+//           |            val y: Int = 1
+//           |            Right.apply[Nothing, Int](x.+(y))
+//           |          }
+//           |        )
+//           |        safeContinuation.getOrThrow()
+//           |      }
+//           |  }
+//           |}
+//           |""".stripMargin
+//      // format: on
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple suspended def with a named implicit Suspend") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def foo()(using s: Suspend): Int =
+//           |  s.suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+//            expectedOneSuspendContinuation)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple suspended def with a context function that has Suspend") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def foo(): Suspend ?=> Int =
+//           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+//            expectedOneSuspendContinuation)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple suspended def with no parameters keeping the rows before the suspend call") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def foo()(using Suspend): Int = {
+//           |  val x = 5
+//           |  println("HI")
+//           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+//           |}
+//           |""".stripMargin
+//
+//      // format: off
+//      val expected =
+//        """|
+//           |package continuations {
+//           |  final lazy module val compileFromString$package:
+//           |    continuations.compileFromString$package
+//           |   = new continuations.compileFromString$package()
+//           |  @SourceFile("compileFromString.scala") final module class
+//           |    compileFromString$package
+//           |  () extends Object() { this: continuations.compileFromString$package.type =>
+//           |    private def writeReplace(): AnyRef =
+//           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+//           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type =
+//           |      {
+//           |        val x: Int = 5
+//           |        println("HI")
+//           |        {
+//           |          val continuation1: continuations.Continuation[Int] = completion
+//           |          val safeContinuation: continuations.SafeContinuation[Int] =
+//           |            new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(),
+//           |              continuations.Continuation.State.Undecided
+//           |            )
+//           |          safeContinuation.resume(Right.apply[Nothing, Int](1))
+//           |          safeContinuation.getOrThrow()
+//           |        }
+//           |      }
+//           |  }
+//           |}
+//           |""".stripMargin
+//      // format: on
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should even convert suspended def with no parameters that doesn't call resume") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def foo()(using Suspend): Int =
+//           |  summon[Suspend].suspendContinuation[Int] { _ => val x = 1; println("Hello") }
+//           |""".stripMargin
+//
+//      // format: off
+//      val expected =
+//        """|
+//           |package continuations {
+//           |  final lazy module val compileFromString$package:
+//           |    continuations.compileFromString$package
+//           |   = new continuations.compileFromString$package()
+//           |  @SourceFile("compileFromString.scala") final module class
+//           |    compileFromString$package
+//           |  () extends Object() { this: continuations.compileFromString$package.type =>
+//           |    private def writeReplace(): AnyRef =
+//           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+//           |    def foo(completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type =
+//           |      {
+//           |        val continuation1: continuations.Continuation[Int] = completion
+//           |        val safeContinuation: continuations.SafeContinuation[Int] =
+//           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(),
+//           |            continuations.Continuation.State.Undecided
+//           |          )
+//           |        val x: Int = 1
+//           |        println("Hello")
+//           |        safeContinuation.getOrThrow()
+//           |      }
+//           |  }
+//           |}
+//           |""".stripMargin
+//      // format: on
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple suspended def with a single constant parameter with a Right input") {
+//    implicit givenContext =>
+//
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def foo(x: Int)(using Suspend): Int =
+//           |  summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(x + 1)) }
+//           |""".stripMargin
+//
+//      // format: off
+//      val expected =
+//        """|
+//           |package continuations {
+//           |  final lazy module val compileFromString$package:
+//           |    continuations.compileFromString$package
+//           |   = new continuations.compileFromString$package()
+//           |  @SourceFile("compileFromString.scala") final module class
+//           |    compileFromString$package
+//           |  () extends Object() { this: continuations.compileFromString$package.type =>
+//           |    private def writeReplace(): AnyRef =
+//           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+//           |    def foo(x: Int, completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type =
+//           |      {
+//           |        val continuation1: continuations.Continuation[Int] = completion
+//           |        val safeContinuation: continuations.SafeContinuation[Int] =
+//           |          new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(),
+//           |            continuations.Continuation.State.Undecided
+//           |          )
+//           |        safeContinuation.resume(Right.apply[Nothing, Int](x.+(1)))
+//           |        safeContinuation.getOrThrow()
+//           |      }
+//           |  }
+//           |}
+//           |""".stripMargin
+//      // format: on
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert a zero arity definition that contains a suspend call but returns a non-suspending value " +
+//      "into a state machine including an update of the call site:") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def program: Int = {
+//           |  def foo()(using Suspend): Int = {
+//           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+//           |    10
+//           |  }
+//           |  foo()
+//           |}
+//           |""".stripMargin
+//
+//      val sourceContextFunction =
+//        """|
+//           |package continuations
+//           |
+//           |def program: Int = {
+//           |  def foo(): Suspend ?=> Int = {
+//           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+//           |    10
+//           |  }
+//           |  foo()
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+//            expectedStateMachineForSuspendContinuationReturningANonSuspendingVal)
+//      }
+//
+//      checkContinuations(sourceContextFunction) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+//            expectedStateMachineForSuspendContinuationReturningANonSuspendingVal)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert a >0 arity definition that contains a suspend call but returns a non-suspending value " +
+//      "into a state machine including an update of the call site:") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def program: Int = {
+//           |  def foo(x: Int)(using Suspend): Int = {
+//           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(x)) }
+//           |    10
+//           |  }
+//           |  foo(11)
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+//            expectedStateMachineWithSingleSuspendedContinuationReturningANonSuspendedVal)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple nested suspended def with a single parameter keeping the rest of the rows untouched") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def foo(x: Int)(using Suspend): Int = {
+//           |  val y = 5
+//           |  println("HI")
+//           |  if (x < y) then {
+//           |    x
+//           |  } else {
+//           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+//           |  }
+//           |}
+//           |""".stripMargin
+//
+//      // format: off
+//      val expected =
+//        """|
+//           |package continuations {
+//           |  final lazy module val compileFromString$package:
+//           |    continuations.compileFromString$package
+//           |   = new continuations.compileFromString$package()
+//           |  @SourceFile("compileFromString.scala") final module class
+//           |    compileFromString$package
+//           |  () extends Object() { this: continuations.compileFromString$package.type =>
+//           |    private def writeReplace(): AnyRef =
+//           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+//           |    def foo(x: Int, completion: continuations.Continuation[Int]): Any | Null | continuations.Continuation.State.Suspended.type =
+//           |      {
+//           |        val y: Int = 5
+//           |        println("HI")
+//           |        if x.<(y) then
+//           |          {
+//           |            x
+//           |          }
+//           |         else
+//           |          {
+//           |            {
+//           |              val continuation1: continuations.Continuation[Int] = completion
+//           |              val safeContinuation: continuations.SafeContinuation[Int] =
+//           |                new continuations.SafeContinuation[Int](continuations.intrinsics.IntrinsicsJvm$package.intercepted[Int](continuation1)(),
+//           |                  continuations.Continuation.State.Undecided
+//           |                )
+//           |              safeContinuation.resume(Right.apply[Nothing, Int](1))
+//           |              safeContinuation.getOrThrow()
+//           |            }
+//           |          }
+//           |      }
+//           |  }
+//           |}
+//           |""".stripMargin
+//      // format: on
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple suspended def with no parameters with multiple `suspendContinuation` that returns " +
+//      "a non-suspending value into a state machine including an update of the call site:") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def program: Int = {
+//           |  def foo()(using Suspend): Int = {
+//           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+//           |    summon[Suspend].suspendContinuation[Boolean] { continuation => continuation.resume(Right(false)) }
+//           |    summon[Suspend].suspendContinuation[String] { continuation => continuation.resume(Right("Hello")) }
+//           |    10
+//           |  }
+//           |
+//           |foo()
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+//            expectedStateMachineMultipleSuspendedContinuationsReturningANonSuspendingVal)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple suspended def with no parameters with multiple `suspendContinuation` that returns " +
+//      "a non-suspending value and with multiple expressions in the suspendContinuation body into a state machine " +
+//      "including an update of the call site:") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def program: Int = {
+//           |  def foo()(using Suspend): Int = {
+//           |    summon[Suspend].suspendContinuation[Int] { continuation =>
+//           |      println("Hello")
+//           |      println("World")
+//           |      continuation.resume(Right(1))
+//           |    }
+//           |    summon[Suspend].suspendContinuation[Boolean] { continuation =>
+//           |      continuation.resume(Right(false))
+//           |      continuation.resume(Right(true))
+//           |    }
+//           |    summon[Suspend].suspendContinuation[String] { continuation =>
+//           |      continuation.resume(Right("Hello"))
+//           |      val x = 1
+//           |    }
+//           |    10
+//           |  }
+//           |
+//           |foo()
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+//            expectedStateMachineWithMultipleResumeReturningANonSuspendedValue)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert a zero arity definition that contains suspend " +
+//      "calls with expressions between them and returns a non-suspending value into a state machine including an update of the call site:") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def program: Int = {
+//           |  def foo()(using Suspend): Int = {
+//           |    println("Start")
+//           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+//           |    val x = "World"
+//           |    println("Hello")
+//           |    println(x)
+//           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(2)) }
+//           |    println("End")
+//           |    10
+//           |  }
+//           |  foo()
+//           |}
+//           |""".stripMargin
+//
+//      val sourceContextFunction =
+//        """|
+//           |package continuations
+//           |
+//           |def program: Int = {
+//           |  def foo(): Suspend ?=> Int = {
+//           |    println("Start")
+//           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+//           |    val x = "World"
+//           |    println("Hello")
+//           |    println(x)
+//           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(2)) }
+//           |    println("End")
+//           |    10
+//           |  }
+//           |  foo()
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+//            expectedStateMachineReturningANonSuspendedValue)
+//      }
+//
+//      checkContinuations(sourceContextFunction) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+//            expectedStateMachineReturningANonSuspendedValue)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple suspended def with no parameters with multiple `suspendContinuation` " +
+//      "into a state machine including an update of the call site:") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def program: Int = {
+//           |  def foo()(using Suspend): Int = {
+//           |    summon[Suspend].suspendContinuation[Boolean] { continuation => continuation.resume(Right(false)) }
+//           |    summon[Suspend].suspendContinuation[String] { continuation => continuation.resume(Right("Hello")) }
+//           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+//           |  }
+//           |
+//           |foo()
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+//            expectedStateMachineNoDependantSuspensions)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple suspended def with no parameters with multiple `suspendContinuation` " +
+//      "and with multiple expressions in the suspendContinuation body into a state machine including an update of the call site:") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def program: Int = {
+//           |  def foo()(using Suspend): Int = {
+//           |    summon[Suspend].suspendContinuation[Boolean] { continuation =>
+//           |      println("Hi")
+//           |      continuation.resume(Right(false))
+//           |    }
+//           |    summon[Suspend].suspendContinuation[String] {
+//           |      continuation => continuation.resume(Right("Hello"))
+//           |      println("World")
+//           |    }
+//           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+//           |  }
+//           |
+//           |foo()
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+//            expectedStateMachineNoDependantSuspensionsWithCodeInside)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert simple suspended def with no parameters with multiple `suspendContinuation` " +
+//      "and with expressions between them into a state machine including an update of the call site:") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def program: Int = {
+//           |  def foo()(using Suspend): Int = {
+//           |    println("Start")
+//           |    val x = 1
+//           |    summon[Suspend].suspendContinuation[Boolean] { continuation => continuation.resume(Right(false)) }
+//           |    println("Hello")
+//           |    summon[Suspend].suspendContinuation[String] { continuation => continuation.resume(Right("Hello")) }
+//           |    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+//           |  }
+//           |
+//           |foo()
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            compileSourceIdentifier.replaceAllIn(tree.show, ""),
+//            expectedStateMachineNoDependantSuspensionsWithCodeBetween)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should transform the method parameters adding a completion one and updating the call site when there is " +
+//      "a `using Suspend` parameter") {
+//    case given Context =>
+//      val sourceNoSuspend =
+//        """|
+//           |package continuations
+//           |
+//           |import scala.concurrent.ExecutionContext
+//           |import concurrent.ExecutionContext.Implicits.global
+//           |
+//           |def program: Int = {
+//           |  def foo[A, B](x: A, y: B)(z: String)(using s: Suspend, ec: ExecutionContext): A = x
+//           |  foo(1,2)("A")
+//           |}
+//           |""".stripMargin
+//
+//      val sourceSuspend =
+//        """|
+//           |package continuations
+//           |
+//           |import scala.concurrent.ExecutionContext
+//           |import concurrent.ExecutionContext.Implicits.global
+//           |
+//           |def program: Int = {
+//           |  def foo[A, B](x: A, y: B)(z: String)(using s: Suspend, ec: ExecutionContext): A =
+//           |    summon[Suspend].suspendContinuation[A] { continuation => continuation.resume(Right(x)) }
+//           |  foo(1,2)("A")
+//           |}
+//           |""".stripMargin
+//
+//      // format: off
+//      val expectedNoSuspend =
+//        """|
+//           |package continuations {
+//           |  import scala.concurrent.ExecutionContext
+//           |  import concurrent.ExecutionContext.Implicits.global
+//           |  final lazy module val compileFromString$package:
+//           |    continuations.compileFromString$package
+//           |   = new continuations.compileFromString$package()
+//           |  @SourceFile("compileFromString.scala") final module class
+//           |    compileFromString$package
+//           |  () extends Object() { this: continuations.compileFromString$package.type =>
+//           |    private def writeReplace(): AnyRef =
+//           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+//           |    def program: Int =
+//           |      {
+//           |        def foo(x: A, y: B, z: String, ec: concurrent.ExecutionContext, completion: continuations.Continuation[A | Any]): Any = x
+//           |        foo(1, 2, "A", concurrent.ExecutionContext.Implicits.global, continuations.jvm.internal.ContinuationStub.contImpl)
+//           |      }
+//           |  }
+//           |}
+//           |""".stripMargin
+//
+//      val expectedSuspend =
+//        """|
+//           |package continuations {
+//           |  import scala.concurrent.ExecutionContext
+//           |  import concurrent.ExecutionContext.Implicits.global
+//           |  final lazy module val compileFromString$package:
+//           |    continuations.compileFromString$package
+//           |   = new continuations.compileFromString$package()
+//           |  @SourceFile("compileFromString.scala") final module class
+//           |    compileFromString$package
+//           |  () extends Object() { this: continuations.compileFromString$package.type =>
+//           |    private def writeReplace(): AnyRef =
+//           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+//           |    def program: Int =
+//           |      {
+//           |        def foo(x: A, y: B, z: String, ec: concurrent.ExecutionContext, completion: continuations.Continuation[A]):
+//           |          Any | Null | continuations.Continuation.State.Suspended.type
+//           |         =
+//           |          {
+//           |            val continuation1: continuations.Continuation[A] = completion
+//           |            val safeContinuation: continuations.SafeContinuation[A] =
+//           |              new continuations.SafeContinuation[A](continuations.intrinsics.IntrinsicsJvm$package.intercepted[A](continuation1)(),
+//           |                continuations.Continuation.State.Undecided
+//           |              )
+//           |            safeContinuation.resume(Right.apply[Nothing, A](x))
+//           |            safeContinuation.getOrThrow()
+//           |          }
+//           |        foo(1, 2, "A", concurrent.ExecutionContext.Implicits.global, continuations.jvm.internal.ContinuationStub.contImpl)
+//           |      }
+//           |  }
+//           |}
+//           |""".stripMargin
+//      // format: on
+//
+//      checkContinuations(sourceNoSuspend) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            removeLineTrailingSpaces(expectedNoSuspend))
+//      }
+//
+//      checkContinuations(sourceSuspend) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            removeLineTrailingSpaces(expectedSuspend))
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should transform a dependent suspendContinuation with one param into a state machine") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def foo(x: Int)(using Suspend): Int = {
+//           |  val y = summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+//           |  x + y
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            removeLineTrailingSpaces(expectedStateMachineOneParamOneDependantContinuation)
+//          )
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should transform a suspend continuation with one parameter into a state machine"
+//  ) {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def foo(qq: Int)(using s: Suspend): Int = {
+//           |  summon[Suspend].suspendContinuation[Unit] { _.resume(Right { println(qq) }) }
+//           |  10
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            removeLineTrailingSpaces(expectedStateMachineOneParamOneNoDependantContinuation)
+//          )
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should transform a suspend continuation with no parameter and code before the continuation " +
+//      "that is used afterwards into a state machine"
+//  ) {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def foo()(using s: Suspend): Int = {
+//           |  val xx = 111
+//           |  println(xx)
+//           |  summon[Suspend].suspendContinuation[Int] { _.resume(Right( 10 )) }
+//           |  xx
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            removeLineTrailingSpaces(
+//              expectedStateMachineNoParamOneNoDependantContinuationCodeBeforeUsedAfter)
+//          )
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should transform a suspend continuation with many dependant continuations " +
+//      "with code around them to a state machine"
+//  ) {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def fooTest(qq: Int)(using s: Suspend): Int = {
+//           |    val pp = 11
+//           |    val xx = s.suspendContinuation[Int] { _.resume(Right { qq - 1 }) }
+//           |    val ww = 13
+//           |    val rr = "AAA"
+//           |    val yy = s.suspendContinuation[String] { _.resume(Right { rr }) }
+//           |    val tt = 100
+//           |    val zz = s.suspendContinuation[Int] { _.resume(Right { ww - 1 }) }
+//           |    println(xx)
+//           |    xx + qq + yy.size + zz + pp + tt
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            removeLineTrailingSpaces(expectedStateMachineManyDependantContinuations)
+//          )
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should transform a suspend continuation with many dependant and no dependant continuations " +
+//      "with code around them to a state machine"
+//  ) {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def fooTest(qq: Int)(using s: Suspend): Int = {
+//           |    val pp = 11
+//           |    val xx = s.suspendContinuation[Int] { _.resume(Right { qq - 1 }) }
+//           |    val ww = 13
+//           |    val rr = "AAA"
+//           |    s.suspendContinuation[String] { _.resume(Right { rr }) }
+//           |    val tt = 100
+//           |    val zz = s.suspendContinuation[Int] { _.resume(Right { ww - 1 }) }
+//           |    println(xx)
+//           |    xx + qq + zz + pp + tt
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            removeLineTrailingSpaces(
+//              expectedStateMachineManyDependantAndNoDependantContinuations)
+//          )
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should transform a suspend continuation with dependant and no dependant continuation at the end" +
+//      "with code around them and inside to a state machine"
+//  ) {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def fooTest(x: Int)(using s: Suspend): Int = {
+//           |    println("Hello")
+//           |    val y = s.suspendContinuation[Int] { _.resume(Right { println("World"); 1 }) }
+//           |    val z = 1
+//           |    s.suspendContinuation[Int] { continuation =>
+//           |      val w = "World"
+//           |      println("Hello")
+//           |      continuation.resume(Right { println(z); x })
+//           |    }
+//           |    val tt = 2
+//           |    x + y + tt
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            removeLineTrailingSpaces(
+//              expectedStateMachineWithDependantAndNoDependantContinuationAtTheEnd)
+//          )
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert into a state machine for one chained suspend continuation"
+//  ) {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def fooTest()(using s: Suspend): Int = {
+//           |    val x = s.suspendContinuation[Int] { _.resume(Right { 1 }) }
+//           |    s.suspendContinuation[Int] { _.resume(Right { x + 1 }) }
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            removeLineTrailingSpaces(expectedStateMachineForOneChainedContinuation)
+//          )
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert into a state machine multiple chained continuations with" +
+//      "code in between and returning a non suspended value"
+//  ) {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def fooTest(q: Int)(using s: Suspend): Int = {
+//           |    println("Hello")
+//           |    val z = 100
+//           |    val x = s.suspendContinuation[Int] { _.resume(Right { 1 + z}) }
+//           |    val j = 9
+//           |    val w = s.suspendContinuation[Int] { _.resume(Right { x + 1 + q}) }
+//           |    println("World")
+//           |    s.suspendContinuation[Int] { _.resume(Right { x + w + 1 + j}) }
+//           |    10
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            removeLineTrailingSpaces(
+//              expectedStateMachineMultipleChainedSuspendContinuationsReturningANonSuspendedVal)
+//          )
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should update the call site for a simple suspended def with a generic param ") {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def program = {
+//           |  case class Foo(i: Int)
+//           |  def foo[A](a: A)(using Suspend): A = a
+//           |  foo(Foo(1))
+//           |}
+//           |""".stripMargin
+//
+//      // format: off
+//      val expected =
+//        """|
+//           |package continuations {
+//           |  final lazy module val compileFromString$package:
+//           |    continuations.compileFromString$package
+//           |   = new continuations.compileFromString$package()
+//           |  @SourceFile("compileFromString.scala") final module class
+//           |    compileFromString$package
+//           |  () extends Object() { this: continuations.compileFromString$package.type =>
+//           |    private def writeReplace(): AnyRef =
+//           |      new scala.runtime.ModuleSerializationProxy(classOf[continuations.compileFromString$package.type])
+//           |    def program: Object =
+//           |      {
+//           |        case class Foo(i: Int) extends Object(), _root_.scala.Product, _root_.scala.Serializable {
+//           |          override def hashCode(): Int =
+//           |            {
+//           |              var acc: Int = -889275714
+//           |              acc = scala.runtime.Statics#mix(acc, this.productPrefix.hashCode())
+//           |              acc = scala.runtime.Statics#mix(acc, Foo.this.i)
+//           |              scala.runtime.Statics#finalizeHash(acc, 1)
+//           |            }
+//           |          override def equals(x$0: Any): Boolean =
+//           |            this.eq(x$0.$asInstanceOf[Object]).||(
+//           |              x$0 match
+//           |                {
+//           |                  case x$0 @ _:Foo @unchecked => this.i.==(x$0.i).&&(x$0.canEqual(this))
+//           |                  case _ => false
+//           |                }
+//           |            )
+//           |          override def toString(): String = scala.runtime.ScalaRunTime._toString(this)
+//           |          override def canEqual(that: Any): Boolean = that.isInstanceOf[Foo @unchecked]
+//           |          override def productArity: Int = 1
+//           |          override def productPrefix: String = "Foo"
+//           |          override def productElement(n: Int): Any =
+//           |            n match
+//           |              {
+//           |                case 0 => this._1
+//           |                case _ => throw new IndexOutOfBoundsException(n.toString())
+//           |              }
+//           |          override def productElementName(n: Int): String =
+//           |            n match
+//           |              {
+//           |                case 0 => "i"
+//           |                case _ => throw new IndexOutOfBoundsException(n.toString())
+//           |              }
+//           |          val i: Int
+//           |          def copy(i: Int): Foo = new Foo(i)
+//           |          def copy$default$1: Int @uncheckedVariance = Foo.this.i
+//           |          def _1: Int = this.i
+//           |        }
+//           |        final lazy module val Foo: Foo = new Foo()
+//           |        final module class Foo() extends AnyRef(), scala.deriving.Mirror.Product { this: Foo.type =>
+//           |          def apply(i: Int): Foo = new Foo(i)
+//           |          def unapply(x$1: Foo): Foo = x$1
+//           |          override def toString: String = "Foo"
+//           |          type MirroredMonoType = Foo
+//           |          def fromProduct(x$0: Product): continuations.compileFromString$package.Foo.MirroredMonoType =
+//           |            new Foo(x$0.productElement(0).$asInstanceOf[Int])
+//           |        }
+//           |        def foo(a: A, completion: continuations.Continuation[A | Any]): Any = a
+//           |        foo(Foo.apply(1), continuations.jvm.internal.ContinuationStub.contImpl):Object & Product & Serializable
+//           |      }
+//           |  }
+//           |}
+//           |""".stripMargin
+//      // format: on
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(compileSourceIdentifier.replaceAllIn(tree.show, ""), expected)
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert into a state machine chained continuations with an input parameter"
+//  ) {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def fooTest(x: Int)(using Suspend): Int = {
+//           |    val y = summon[Suspend].suspendContinuation[Int] { continuation =>
+//           |      continuation.resume(Right(x + 1))
+//           |    }
+//           |    summon[Suspend].suspendContinuation[Int] { continuation =>
+//           |      continuation.resume(Right(y + 1))
+//           |    }
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            removeLineTrailingSpaces(
+//              expectedStateMachineChainedSuspendContinuationsOneParameter)
+//          )
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "it should convert into a state machine chained continuations with an input parameter and vals"
+//  ) {
+//    case given Context =>
+//      val source =
+//        """|
+//           |package continuations
+//           |
+//           |def fooTest(x: Int)(using Suspend): Int = {
+//           |    val q = 2
+//           |    val w = 3
+//           |    val y = summon[Suspend].suspendContinuation[Int] { continuation =>
+//           |      continuation.resume(Right(x + w))
+//           |    }
+//           |    val p = 1
+//           |    val t = 1
+//           |    val z = summon[Suspend].suspendContinuation[Int] { continuation =>
+//           |      continuation.resume(Right(y + q + x))
+//           |    }
+//           |    z + y + p
+//           |}
+//           |""".stripMargin
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            removeLineTrailingSpaces(
+//              expectedStateMachineChainedSuspendContinuationsOneParameterAndVals)
+//          )
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "It should convert a polymorphic function with suspended context and a non suspended body to CPS"
+//  ) {
+//    case given Context =>
+//      val source =
+//        """
+//          |import continuations.*
+//          |
+//          |def foo: Suspend ?=> Int => Int = x => x + 1
+//          |""".stripMargin
+//
+//      // format: off
+//      val expected =
+//        """|package <empty> {
+//           |  import continuations.*
+//           |  final lazy module val compileFromString$package:
+//           |    compileFromString$package
+//           |   = new compileFromString$package()
+//           |  @SourceFile("compileFromString.scala") final module class
+//           |    compileFromString$package
+//           |  () extends Object() { this: compileFromString$package.type =>
+//           |    private def writeReplace(): AnyRef =
+//           |      new scala.runtime.ModuleSerializationProxy(classOf[compileFromString$package.type])
+//           |    def foo(completion: continuations.Continuation[(Int => Int) | Any]): Int => Any =
+//           |      {
+//           |        def $anonfun(x: Int): Any = x.+(1)
+//           |        closure($anonfun)
+//           |      }
+//           |  }
+//           |}
+//           |""".stripMargin
+//      // format: on
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            removeLineTrailingSpaces(expected))
+//      }
+//  }
+//
+//  compilerContextWithContinuationsPlugin.test(
+//    "It should convert a polymorphic function value with suspended context param a non suspended body to CPS"
+//  ) {
+//    case given Context =>
+//      val source =
+//        """
+//          |import continuations.*
+//          |
+//          |val foo:  Suspend ?=> [A] => List[A] => Int = [A] => (list: List[A]) => list.size
+//          |""".stripMargin
+//
+//      // format: off
+//      val expected =
+//        """|package <empty> {
+//           |  import continuations.*
+//           |  final lazy module val compileFromString$package:
+//           |    compileFromString$package
+//           |   = new compileFromString$package()
+//           |  @SourceFile("compileFromString.scala") final module class
+//           |    compileFromString$package
+//           |  () extends Object() { this: compileFromString$package.type =>
+//           |    private def writeReplace(): AnyRef =
+//           |      new scala.runtime.ModuleSerializationProxy(classOf[compileFromString$package.type])
+//           |    def foo(completion: continuations.Continuation[([A] => (List[A]) => Int) | Any]): [A] => (List[A]) => Any =
+//           |      {
+//           |        final class $anon() extends Object(), PolyFunction {
+//           |          def apply[A >: Nothing <: Any](list: List[A]): Int = list.size
+//           |        }
+//           |        new $anon():([A] => (List[A]) => Int)
+//           |      }
+//           |  }
+//           |}
+//           |""".stripMargin
+//      // format: on
+//
+//      checkContinuations(source) {
+//        case (tree, _) =>
+//          assertNoDiff(
+//            removeLineTrailingSpaces(compileSourceIdentifier.replaceAllIn(tree.show, "")),
+//            removeLineTrailingSpaces(expected))
+//      }
+//  }
 }

--- a/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
@@ -1200,12 +1200,12 @@ trait StateMachineFixtures {
        |                if $result.!=(null) then
        |                  $result.fold[Unit](
        |                    {
-       |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+       |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
        |                      closure($anonfun)
        |                    }
        |                  ,
        |                    {
-       |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
        |                      closure($anonfun)
        |                    }
        |                  )
@@ -1237,12 +1237,12 @@ trait StateMachineFixtures {
        |                if $result.!=(null) then
        |                  $result.fold[Unit](
        |                    {
-       |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+       |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
        |                      closure($anonfun)
        |                    }
        |                  ,
        |                    {
-       |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
        |                      closure($anonfun)
        |                    }
        |                  )
@@ -1340,12 +1340,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -1382,12 +1382,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -1485,12 +1485,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -1523,12 +1523,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -1646,12 +1646,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -1700,12 +1700,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -1775,12 +1775,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -1866,12 +1866,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -1987,12 +1987,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2041,12 +2041,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2115,12 +2115,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2196,12 +2196,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2305,12 +2305,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2351,12 +2351,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2408,12 +2408,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2512,12 +2512,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2547,12 +2547,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2591,12 +2591,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2704,12 +2704,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2750,12 +2750,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2815,12 +2815,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2887,12 +2887,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2995,12 +2995,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -3033,12 +3033,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -3080,12 +3080,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -3196,12 +3196,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -3245,12 +3245,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -3313,12 +3313,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -3424,12 +3424,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -3477,12 +3477,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -3539,12 +3539,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4122,12 +4122,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4184,12 +4184,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4255,12 +4255,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4367,12 +4367,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4420,12 +4420,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4482,12 +4482,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4592,12 +4592,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4645,12 +4645,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4707,12 +4707,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4817,12 +4817,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4871,12 +4871,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4933,12 +4933,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5043,12 +5043,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5097,12 +5097,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5159,12 +5159,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5269,12 +5269,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5324,12 +5324,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5386,12 +5386,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5496,12 +5496,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5551,12 +5551,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5613,12 +5613,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5726,12 +5726,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5790,12 +5790,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5861,12 +5861,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5974,12 +5974,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6038,12 +6038,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6110,12 +6110,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6226,12 +6226,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6299,12 +6299,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6380,12 +6380,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6493,12 +6493,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6557,12 +6557,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6630,12 +6630,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6746,12 +6746,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6819,12 +6819,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6901,12 +6901,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7017,12 +7017,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7090,12 +7090,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7172,12 +7172,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7291,12 +7291,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7364,12 +7364,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7447,12 +7447,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7567,12 +7567,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7640,12 +7640,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7723,12 +7723,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7844,12 +7844,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7917,12 +7917,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -8000,12 +8000,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -8121,12 +8121,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -8194,12 +8194,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -8277,12 +8277,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -8399,12 +8399,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -8472,12 +8472,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -8554,12 +8554,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )

--- a/zero-arguments-no-continuation-treeview/src/main/scala/ZeroArgumentsZeroContinuations.scala
+++ b/zero-arguments-no-continuation-treeview/src/main/scala/ZeroArgumentsZeroContinuations.scala
@@ -3,5 +3,33 @@ package examples
 import continuations.*
 
 @main def ZeroArgumentsZeroContinuations =
-  def zeroArgumentsZeroContinuations()(using Suspend): Int = 1
-  println(zeroArgumentsZeroContinuations())
+  1
+//  println(ExampleObject.oneArgumentsSingleResumeContinuations(1))
+//  println(program.foo(1))
+
+//object ExampleObject:
+//  private def test(x: Int) = x + 1
+//  private val z = 1
+//  def oneArgumentsSingleResumeContinuations(x: Int)(using s: Suspend): Int =
+//    def test2(x: Int) = x + 1
+//    val z2 = 1
+//    s.suspendContinuation[Int] { continuation =>
+//      def test3(x: Int) = x // TODO: x+1
+//      val z3 = 1
+//      continuation.resume {
+//        val z4 = 1
+//        def test4(x: Int) = x // TODO: x+1
+//        Right(test(x) + 1 + z + z2 + test2(x) + z3 + test3(x) + z4 + test4(x))
+//      }
+//    }
+//    val qq = s.suspendContinuation[Int] { continuation =>
+//      continuation.resume(Right(test(x) + 1))
+//    }
+//    1
+
+object program {
+  def foo()(using Suspend): Int = {
+    summon[Suspend].suspendContinuation[Int] { continuation => continuation.resume(Right(1)) }
+    1
+  }
+}


### PR DESCRIPTION
`Failed to find name hashes for examples.program$.program$foo$1`
where `foo` is the class we create for the state machine ` class program$foo$1($completion: continuations.Continuation[Any | Null])`

reproduce it with 
```
zero-arguments-no-continuation-treeview/clean
zero-arguments-no-continuation-treeview/compile
```