### PR TITLE
CU-8677bmjpu - Compiler Plugin: Suspend in non-companion object

### DIFF
--- a/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
+++ b/continuationsPlugin/src/main/scala/continuations/DefDefTransforms.scala
@@ -34,7 +34,7 @@ object DefDefTransforms extends TreesChecks:
         .requiredType("Continuation")
         .typeRef
         .appliedTo(returnType)
-    )
+    ).entered
 
   private def params(tree: tpd.ValOrDefDef, completionSym: Symbol)(
       using Context): List[tpd.ParamClause] =
@@ -126,7 +126,7 @@ object DefDefTransforms extends TreesChecks:
       ),
       parent.privateWithin,
       parent.coord
-    )
+    ).entered
 
   private def removeSuspend(typ: Type, returnValue: Option[Type] = None)(using Context): Type =
     val types = flattenTypes(typ)
@@ -173,6 +173,9 @@ object DefDefTransforms extends TreesChecks:
       (returnType, rhs, contextFunctionOwner)
     else (tree.tpt.tpe, tree.rhs, Option.empty)
 
+  private def deleteOldSymbol(sym: Symbol)(using Context): Unit =
+    sym.enclosingClass.asClass.delete(sym)
+
   private def transformSuspendOneContinuationResume(
       tree: tpd.ValOrDefDef,
       suspensionPoint: tpd.Tree)(using Context): tpd.DefDef =
@@ -211,7 +214,7 @@ object DefDefTransforms extends TreesChecks:
     val transformedMethodSymbol =
       createTransformedMethodSymbol(parent, transformedMethodParams, finalMethodReturnType.tpe)
 
-    parent.owner.unforcedDecls.openForMutations.replace(parent, transformedMethodSymbol)
+    deleteOldSymbol(parent)
 
     val transformedMethod =
       tpd.DefDef(sym = transformedMethodSymbol)
@@ -225,7 +228,7 @@ object DefDefTransforms extends TreesChecks:
           transformedMethodSymbol,
           termName("continuation1"),
           Flags.Local,
-          continuationTyped),
+          continuationTyped).entered,
         rhs = transformedMethodCompletionParam)
 
     val undecidedState =
@@ -250,7 +253,7 @@ object DefDefTransforms extends TreesChecks:
           transformedMethodSymbol,
           termName("safeContinuation"),
           Flags.Local,
-          safeContinuationConstructor.tpe),
+          safeContinuationConstructor.tpe).entered,
         safeContinuationConstructor)
 
     val safeContinuationRef =
@@ -365,7 +368,7 @@ object DefDefTransforms extends TreesChecks:
         removeSuspendReturnAny(methodReturnType)
       )
 
-    parent.owner.unforcedDecls.openForMutations.replace(parent, transformedMethodSymbol)
+    deleteOldSymbol(parent)
 
     val transformedMethod =
       tpd.DefDef(sym = transformedMethodSymbol)
@@ -597,7 +600,7 @@ object DefDefTransforms extends TreesChecks:
         val transformedMethodSymbol =
           createTransformedMethodSymbol(parent, transformedMethodParams, newReturnType.tpe)
 
-        treeOwner.unforcedDecls.openForMutations.replace(parent, transformedMethodSymbol)
+        deleteOldSymbol(parent)
 
         val transformedMethod: tpd.DefDef =
           tpd.DefDef(sym = transformedMethodSymbol)
@@ -730,7 +733,7 @@ object DefDefTransforms extends TreesChecks:
                   tree.symbol.asTerm.name,
                   Local | Mutable | Synthetic,
                   tree.symbol.info,
-                  coord = tree.symbol.coord),
+                  coord = tree.symbol.coord).entered,
                 nullLiteral
               )
             }
@@ -745,7 +748,7 @@ object DefDefTransforms extends TreesChecks:
                   Local | Mutable | Synthetic,
                   vd.symbol.info,
                   coord = vd.symbol.coord
-                ),
+                ).entered,
                 ref(vd.symbol)
               )
           }
@@ -798,7 +801,10 @@ object DefDefTransforms extends TreesChecks:
               newParent,
               termName("$continuation"),
               Local | Mutable | Synthetic,
-              OrType(continuationClassRef.appliedTo(anyType), defn.NullType, soft = false)),
+              OrType(
+                continuationClassRef.appliedTo(anyType),
+                defn.NullType,
+                soft = false)).entered,
             nullLiteral
           )
 
@@ -808,7 +814,7 @@ object DefDefTransforms extends TreesChecks:
               .appliedToType(continuationStateMachineClass.tpe)
 
           val case11Param =
-            newSymbol(newParent, nme.x_0, Flags.Case | Flags.CaseAccessor, defn.AnyType)
+            newSymbol(newParent, nme.x_0, Flags.Case | Flags.CaseAccessor, defn.AnyType).entered
           val $continuationLabel =
             continuationAsStateMachineClass.select(continuationsStateMachineLabelParam)
           val case11 = tpd.CaseDef(
@@ -865,7 +871,7 @@ object DefDefTransforms extends TreesChecks:
                 newParent,
                 termName("$result"),
                 Local,
-                eitherThrowableAnyNullSuspendedType),
+                eitherThrowableAnyNullSuspendedType).entered,
               continuationAsStateMachineClass.select(continuationsStateMachineResultName)
             )
 
@@ -879,11 +885,15 @@ object DefDefTransforms extends TreesChecks:
                 .select(termName("fold"))
                 .appliedToType(defn.UnitType)
                 .appliedTo(
-                  tpd.Lambda(
-                    MethodType.apply(List(defn.ThrowableType))(_ => defn.NothingType),
-                    trees => tpd.Throw(trees.head)),
-                  tpd.Lambda(
-                    MethodType(List(anyNullSuspendedType))(_ => defn.UnitType),
+                  tpd.Closure(
+                    newAnonFun(
+                      newParent,
+                      MethodType(List(defn.ThrowableType))(_ => defn.NothingType)),
+                    trees => tpd.Throw(trees.head.head)),
+                  tpd.Closure(
+                    newAnonFun(
+                      newParent,
+                      MethodType(List(anyNullSuspendedType))(_ => defn.UnitType)),
                     _ => unitLiteral)
                 ),
               unitLiteral
@@ -891,7 +901,7 @@ object DefDefTransforms extends TreesChecks:
 
           val labels: List[Symbol] =
             rowsBeforeSuspensionPoint.keySet.toList.indices.toList.map { i =>
-              newSymbol(newParent, termName(s"label$i"), Flags.Label, defn.UnitType)
+              newSymbol(newParent, termName(s"label$i"), Flags.Label, defn.UnitType).entered
             }
 
           def paramsAndRowsBeforeSuspendIncludingSuspend(index: Int) =
@@ -968,7 +978,7 @@ object DefDefTransforms extends TreesChecks:
                       newParent,
                       termName("safeContinuation"),
                       Flags.Local,
-                      safeContinuationConstructor.tpe),
+                      safeContinuationConstructor.tpe).entered,
                     safeContinuationConstructor)
 
                 val safeContinuationRef =
@@ -983,7 +993,7 @@ object DefDefTransforms extends TreesChecks:
                       newParent,
                       termName("orThrow"),
                       Flags.Local,
-                      anyNullSuspendedType),
+                      anyNullSuspendedType).entered,
                     safeContinuationRef.select(termName("getOrThrow")).appliedToNone)
 
                 val assignGetOrThrowToGlobalVar =

--- a/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
+++ b/continuationsPlugin/src/test/scala/continuations/StateMachineFixtures.scala
@@ -1200,12 +1200,12 @@ trait StateMachineFixtures {
        |                if $result.!=(null) then
        |                  $result.fold[Unit](
        |                    {
-       |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+       |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
        |                      closure($anonfun)
        |                    }
        |                  ,
        |                    {
-       |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
        |                      closure($anonfun)
        |                    }
        |                  )
@@ -1237,12 +1237,12 @@ trait StateMachineFixtures {
        |                if $result.!=(null) then
        |                  $result.fold[Unit](
        |                    {
-       |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+       |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
        |                      closure($anonfun)
        |                    }
        |                  ,
        |                    {
-       |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+       |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
        |                      closure($anonfun)
        |                    }
        |                  )
@@ -1340,12 +1340,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -1382,12 +1382,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -1485,12 +1485,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -1523,12 +1523,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -1646,12 +1646,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -1700,12 +1700,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -1775,12 +1775,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -1866,12 +1866,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -1987,12 +1987,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2041,12 +2041,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2115,12 +2115,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2196,12 +2196,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2305,12 +2305,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2351,12 +2351,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2408,12 +2408,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2512,12 +2512,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2547,12 +2547,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2591,12 +2591,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2704,12 +2704,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2750,12 +2750,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2815,12 +2815,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2887,12 +2887,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -2995,12 +2995,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -3033,12 +3033,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -3080,12 +3080,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -3196,12 +3196,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -3245,12 +3245,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -3313,12 +3313,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -3424,12 +3424,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -3477,12 +3477,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -3539,12 +3539,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4122,12 +4122,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4184,12 +4184,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4255,12 +4255,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4367,12 +4367,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4420,12 +4420,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4482,12 +4482,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4592,12 +4592,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4645,12 +4645,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4707,12 +4707,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4817,12 +4817,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4871,12 +4871,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -4933,12 +4933,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5043,12 +5043,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5097,12 +5097,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5159,12 +5159,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5269,12 +5269,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5324,12 +5324,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5386,12 +5386,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5496,12 +5496,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5551,12 +5551,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5613,12 +5613,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5726,12 +5726,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5790,12 +5790,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5861,12 +5861,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -5974,12 +5974,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6038,12 +6038,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6110,12 +6110,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6226,12 +6226,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6299,12 +6299,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6380,12 +6380,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6493,12 +6493,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6557,12 +6557,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6630,12 +6630,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6746,12 +6746,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6819,12 +6819,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -6901,12 +6901,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7017,12 +7017,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7090,12 +7090,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7172,12 +7172,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7291,12 +7291,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7364,12 +7364,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7447,12 +7447,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7567,12 +7567,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7640,12 +7640,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7723,12 +7723,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7844,12 +7844,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -7917,12 +7917,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -8000,12 +8000,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -8121,12 +8121,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -8194,12 +8194,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -8277,12 +8277,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -8399,12 +8399,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -8472,12 +8472,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )
@@ -8554,12 +8554,12 @@ trait StateMachineFixtures {
       |                if $result.!=(null) then
       |                  $result.fold[Unit](
       |                    {
-      |                      def $anonfun(val x$0: Throwable): Nothing = throw x$0
+      |                      def $anonfun(x$0: Throwable): Nothing = throw x$0
       |                      closure($anonfun)
       |                    }
       |                  ,
       |                    {
-      |                      def $anonfun(val x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
+      |                      def $anonfun(x$0: Any | Null | (continuations.Continuation.State.Suspended : continuations.Continuation.State)): Unit = ()
       |                      closure($anonfun)
       |                    }
       |                  )

--- a/zero-arguments-no-continuation-treeview/src/main/scala/ZeroArgumentsZeroContinuations.scala
+++ b/zero-arguments-no-continuation-treeview/src/main/scala/ZeroArgumentsZeroContinuations.scala
@@ -3,5 +3,38 @@ package examples
 import continuations.*
 
 @main def ZeroArgumentsZeroContinuations =
-  def zeroArgumentsZeroContinuations()(using Suspend): Int = 1
-  println(zeroArgumentsZeroContinuations())
+  println(ExampleObject.oneArgumentsSingleResumeContinuations(1))
+  println(program.foo(2))
+
+object ExampleObject:
+  private def test(x: Int) = x + 1
+  private val z = 1
+  def oneArgumentsSingleResumeContinuations(x: Int)(using s: Suspend): Int =
+    def test2(x: Int) = x + 1
+    val z2 = 1
+    s.suspendContinuation[Int] { continuation =>
+      def test3(x: Int) = x // TODO: x+1
+      val z3 = 1
+      continuation.resume {
+        val z4 = 1
+        def test4(x: Int) = x // TODO: x+1
+        Right(test(x) + 1 + z + z2 + test2(x) + z3 + test3(x) + z4 + test4(x))
+      }
+    }
+    val qq = s.suspendContinuation[Int] { continuation =>
+      continuation.resume(Right(test(x) + 1))
+    }
+    2 + qq
+
+object program {
+  def foo(x: Int)(using Suspend): Int = {
+    val q = summon[Suspend].suspendContinuation[Int] { continuation =>
+      continuation.resume(Right(1 + x))
+    }
+    val y = 2
+    val qq = summon[Suspend].suspendContinuation[Int] { continuation =>
+      continuation.resume(Right(1 + x))
+    }
+    q + 1 + qq + x + y
+  }
+}


### PR DESCRIPTION
- sbt returns an error:

`Failed to find name hashes for examples.program$.program$foo$1`
where `foo` is the class we create for the state machine ` class program$foo$1($completion: continuations.Continuation[Any | Null])`

reproduce it with 
```
zero-arguments-no-continuation-treeview/clean
zero-arguments-no-continuation-treeview/compile
```

- however there seems to be a bug in sbt, see [here](https://github.com/sbt/sbt/issues/7157)

using `scalac:3.1.2` or `scala` seems to create the correct tree and work

```
env JAVA_OPTS='--enable-preview --add-modules jdk.incubator.concurrent' scalac -classpath continuationsPlugin/target/scala-3.1.2/classes -d zero-arguments-no-continuation-treeview/target/scala-3.1.2/classes -Xplugin:continuationsPlugin/target/scala-3.1.2/continuationsplugin_3-0.0.0+146-d84ba681+20230227-1101-SNAPSHOT.jar zero-arguments-no-continuation-treeview/src/main/scala/ZeroArgumentsZeroContinuations.scala
```